### PR TITLE
Add config header

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,17 @@ Config flags
 
 By default all flags are set except for DFU upload, so it's most secure.
 
+
+Config header
+-------------
+
+You can customize some bootloader parameters in *user_config.h* header or also define them in
+CONFIG environment variable.
+
+* USB_VID: Sets Vendor ID. Default is `0xdead`.
+* USB_PID: Sets Product ID. Default is `0xca5d`.
+* USB_MANUFACTURER: Sets iManufacturer string. Default is `"davidgf.net (libopencm3 based)"`.
+* USB_PRODUCT: Sets iProduct string. Default is `"DFU bootloader [" VERSION "]"`, where `VERSION` is
+  git tag version.
+* USB_SERIALNUMBER: Sets iSerialNumber string. Default is chip's unique ID.
+

--- a/config.h
+++ b/config.h
@@ -1,0 +1,22 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include "user_config.h"
+
+#ifndef USB_VID
+#define USB_VID 0xdead
+#endif
+
+#ifndef USB_PID
+#define USB_PID 0xca5d
+#endif
+
+#ifndef USB_MANUFACTURER
+#define USB_MANUFACTURER "davidgf.net (libopencm3 based)"
+#endif
+
+#ifndef USB_PRODUCT
+#define USB_PRODUCT "DFU bootloader [" VERSION "]"
+#endif
+
+#endif //CONFIG_H

--- a/main.c
+++ b/main.c
@@ -22,6 +22,7 @@
 #include "reboot.h"
 #include "flash.h"
 #include "watchdog.h"
+#include "config.h"
 
 /* Commands sent with wBlockNum == 0 as per ST implementation. */
 #define CMD_SETADDR	0x21
@@ -42,15 +43,21 @@ static struct {
 	uint16_t blocknum;
 } prog;
 
+#ifndef USB_SERIALNUMBER
 // Serial number to expose via USB
 static char serial_no[25];
+#endif
 
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)
 const char * const _usb_strings[5] = {
-	"davidgf.net (libopencm3 based)", // iManufacturer
-	"DFU bootloader [" VERSION "]", // iProduct
+	USB_MANUFACTURER, // iManufacturer
+	USB_PRODUCT, // iProduct
+#ifndef USB_SERIALNUMBER
 	serial_no, // iSerialNumber
+#else
+	USB_SERIALNUMBER, // iSerialNumber
+#endif
 	// Interface desc string
 	/* This string is used by ST Microelectronics' DfuSe utility. */
 	/* Change check_do_erase() accordingly */
@@ -73,6 +80,7 @@ const char * const _usb_strings[5] = {
 	#endif
 };
 
+#ifndef USB_SERIALNUMBER
 static const char hcharset[16] = "0123456789abcdef";
 static void get_dev_unique_id(char *s) {
 	volatile uint8_t *unique_id = (volatile uint8_t *)0x1FFFF7E8;
@@ -82,6 +90,7 @@ static void get_dev_unique_id(char *s) {
 		s[i+1] = hcharset[*unique_id++ & 0xF];
 	}
 }
+#endif
 
 static uint8_t usbdfu_getstatus(uint32_t *bwPollTimeout) {
 	switch (usbdfu_state) {
@@ -463,7 +472,9 @@ int main(void) {
 	for (unsigned int i = 0; i < 100000; i++)
 		__asm__("nop");
 
+#ifndef USB_SERIALNUMBER
 	get_dev_unique_id(serial_no);
+#endif
 	usb_init();
 
 	while (1) {

--- a/usb.c
+++ b/usb.c
@@ -5,6 +5,7 @@
 #include <string.h>
 
 #include "usb.h"
+#include "config.h"
 
 // Defined in main
 extern uint8_t usbd_control_buffer[1024];
@@ -29,8 +30,8 @@ const struct usb_device_descriptor dev_desc = {
 	.bDeviceSubClass = 0,
 	.bDeviceProtocol = 0,
 	.bMaxPacketSize0 = 64,
-	.idVendor = 0xdead,
-	.idProduct = 0xca5d,
+	.idVendor = USB_VID,
+	.idProduct = USB_PID,
 	.bcdDevice = 0x0200,
 	.iManufacturer = 1,
 	.iProduct = 2,

--- a/user_config.h
+++ b/user_config.h
@@ -1,0 +1,11 @@
+#ifndef USER_CONFIG_H
+#define USER_CONFIG_H
+
+//#define USB_VID 0x1209
+//#define USB_PID 0x4242
+
+//#define USB_MANUFACTURER "Yet Another Manufacturer"
+//#define USB_PRODUCT      "Yet Another Product"
+//#define USB_SERIALNUMBER "#000001"
+
+#endif //USER_CONFIG_H


### PR DESCRIPTION
Config header allows customize some bootloader parameters like USB
Device Descriptor fields in `user_config.h` file.